### PR TITLE
(Functional) Fix of overlapping logo

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -13,7 +13,7 @@
   <bibtex src="/papers.bib"></bibtex>
 </head>
 <body>
-        <div class="page-border"><header><nav class="white z-depth-0" role="navigation">
+        <div class="page-border"><header class="white"><nav class="white z-depth-0" role="navigation">
   <div class="nav-wrapper container">
     <a href="/" class="brand-logo">CHR2024</a>
     <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>

--- a/docs/announcements/index.html
+++ b/docs/announcements/index.html
@@ -13,7 +13,7 @@
   <bibtex src="/papers.bib"></bibtex>
 </head>
 <body>
-        <div class="page-border"><header><nav class="white z-depth-0" role="navigation">
+        <div class="page-border"><header class="white"><nav class="white z-depth-0" role="navigation">
   <div class="nav-wrapper container">
     <a href="/" class="brand-logo">CHR2024</a>
     <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>

--- a/docs/announcements/lauren-klein/index.html
+++ b/docs/announcements/lauren-klein/index.html
@@ -13,7 +13,7 @@
   <bibtex src="/papers.bib"></bibtex>
 </head>
 <body>
-        <div class="page-border"><header><nav class="white z-depth-0" role="navigation">
+        <div class="page-border"><header class="white"><nav class="white z-depth-0" role="navigation">
   <div class="nav-wrapper container">
     <a href="/" class="brand-logo">CHR2024</a>
     <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>

--- a/docs/announcements/leon-derczynski/index.html
+++ b/docs/announcements/leon-derczynski/index.html
@@ -13,7 +13,7 @@
   <bibtex src="/papers.bib"></bibtex>
 </head>
 <body>
-        <div class="page-border"><header><nav class="white z-depth-0" role="navigation">
+        <div class="page-border"><header class="white"><nav class="white z-depth-0" role="navigation">
   <div class="nav-wrapper container">
     <a href="/" class="brand-logo">CHR2024</a>
     <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>

--- a/docs/archive/index.html
+++ b/docs/archive/index.html
@@ -13,7 +13,7 @@
   <bibtex src="/papers.bib"></bibtex>
 </head>
 <body>
-        <div class="page-border"><header><nav class="white z-depth-0" role="navigation">
+        <div class="page-border"><header class="white"><nav class="white z-depth-0" role="navigation">
   <div class="nav-wrapper container">
     <a href="/" class="brand-logo">CHR2024</a>
     <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>

--- a/docs/cfp/index.html
+++ b/docs/cfp/index.html
@@ -13,7 +13,7 @@
   <bibtex src="/papers.bib"></bibtex>
 </head>
 <body>
-        <div class="page-border"><header><nav class="white z-depth-0" role="navigation">
+        <div class="page-border"><header class="white"><nav class="white z-depth-0" role="navigation">
   <div class="nav-wrapper container">
     <a href="/" class="brand-logo">CHR2024</a>
     <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>

--- a/docs/code-of-conduct/index.html
+++ b/docs/code-of-conduct/index.html
@@ -13,7 +13,7 @@
   <bibtex src="/papers.bib"></bibtex>
 </head>
 <body>
-        <div class="page-border"><header><nav class="white z-depth-0" role="navigation">
+        <div class="page-border"><header class="white"><nav class="white z-depth-0" role="navigation">
   <div class="nav-wrapper container">
     <a href="/" class="brand-logo">CHR2024</a>
     <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>

--- a/docs/community/index.html
+++ b/docs/community/index.html
@@ -13,7 +13,7 @@
   <bibtex src="/papers.bib"></bibtex>
 </head>
 <body>
-        <div class="page-border"><header><nav class="white z-depth-0" role="navigation">
+        <div class="page-border"><header class="white"><nav class="white z-depth-0" role="navigation">
   <div class="nav-wrapper container">
     <a href="/" class="brand-logo">CHR2024</a>
     <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -13,7 +13,7 @@
   <bibtex src="/papers.bib"></bibtex>
 </head>
 <body>
-        <div class="page-border"><header><nav class="white z-depth-0" role="navigation">
+        <div class="page-border"><header class="white"><nav class="white z-depth-0" role="navigation">
   <div class="nav-wrapper container">
     <a href="/" class="brand-logo">CHR2024</a>
     <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -73,6 +73,10 @@ ul li::before {
     margin-left: 0em; /* Negative margin to align with the list content */
 }
 
+#nav-mobile {
+    margin-left: 200px;
+}
+
 nav ul li::before {
     content: ""; /* No dash before nav list item */
     display: inline; /* Make the pseudo-element inline */

--- a/docs/hosting/index.html
+++ b/docs/hosting/index.html
@@ -13,7 +13,7 @@
   <bibtex src="/papers.bib"></bibtex>
 </head>
 <body>
-        <div class="page-border"><header><nav class="white z-depth-0" role="navigation">
+        <div class="page-border"><header class="white"><nav class="white z-depth-0" role="navigation">
   <div class="nav-wrapper container">
     <a href="/" class="brand-logo">CHR2024</a>
     <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
   <bibtex src="/papers.bib"></bibtex>
 </head>
 <body>
-        <div class="page-border"><header><nav class="white z-depth-0" role="navigation">
+        <div class="page-border"><header class="white"><nav class="white z-depth-0" role="navigation">
   <div class="nav-wrapper container">
     <a href="/" class="brand-logo">CHR2024</a>
     <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>

--- a/docs/people/index.html
+++ b/docs/people/index.html
@@ -13,7 +13,7 @@
   <bibtex src="/papers.bib"></bibtex>
 </head>
 <body>
-        <div class="page-border"><header><nav class="white z-depth-0" role="navigation">
+        <div class="page-border"><header class="white"><nav class="white z-depth-0" role="navigation">
   <div class="nav-wrapper container">
     <a href="/" class="brand-logo">CHR2024</a>
     <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>

--- a/docs/programme/index.html
+++ b/docs/programme/index.html
@@ -13,7 +13,7 @@
   <bibtex src="/papers.bib"></bibtex>
 </head>
 <body>
-        <div class="page-border"><header><nav class="white z-depth-0" role="navigation">
+        <div class="page-border"><header class="white"><nav class="white z-depth-0" role="navigation">
   <div class="nav-wrapper container">
     <a href="/" class="brand-logo">CHR2024</a>
     <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>

--- a/docs/venue/index.html
+++ b/docs/venue/index.html
@@ -13,7 +13,7 @@
   <bibtex src="/papers.bib"></bibtex>
 </head>
 <body>
-        <div class="page-border"><header><nav class="white z-depth-0" role="navigation">
+        <div class="page-border"><header class="white"><nav class="white z-depth-0" role="navigation">
   <div class="nav-wrapper container">
     <a href="/" class="brand-logo">CHR2024</a>
     <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>

--- a/themes/chr/layouts/partials/header.html
+++ b/themes/chr/layouts/partials/header.html
@@ -1,1 +1,1 @@
-<header>{{- partial "sidebar.html" . -}}</header>
+<header class="white">{{- partial "sidebar.html" . -}}</header>

--- a/themes/chr/static/css/main.css
+++ b/themes/chr/static/css/main.css
@@ -73,6 +73,10 @@ ul li::before {
     margin-left: 0em; /* Negative margin to align with the list content */
 }
 
+#nav-mobile {
+    margin-left: 200px;
+}
+
 nav ul li::before {
     content: ""; /* No dash before nav list item */
     display: inline; /* Make the pseudo-element inline */


### PR DESCRIPTION
Fixed #12 

It is mostly a functional fix -> could be done some aesthetics things such as reducing whitespace between rows, but everything is aligned now, and the logo does not overlap. 

## Notes
Added "class white" to the header.html in partials (to avoid the colored bar when minimising the window) `<header class="white">{{- partial "sidebar.html" . -}}</header>`and add a margin to the elements in themes/chr/static/css/main.css: 
```
#nav-mobile {
    margin-left: 200px;
}
```