### PR TITLE
feat: add to max people to workshop description

### DIFF
--- a/content/programme.md
+++ b/content/programme.md
@@ -87,6 +87,9 @@ layouttype: "single"
             understanding of the process. It is particularly suited for early career researchers, while senior researchers are also encouraged to attend and engage in discussions on theory and methodology. 
             Participants will gain practical experience with advanced NLP methods, statistical modeling, and computational approaches to reader response studies. Basic familiarity with Python is recommended.
             (<a href="https://igelsociety.github.io/CHR2024-book-reviews-workshop/">https://igelsociety.github.io/CHR2024-book-reviews-workshop/</a>)
+            <br>
+            <br>
+            <i> Note: A maximum of 30 people can attend this workshop, and registered participants of the conference who indicated an interest in this workshop are selected on a first-come-first-serve basis.</i>
           </span>
         </div>
       </span>

--- a/docs/programme/index.html
+++ b/docs/programme/index.html
@@ -192,6 +192,9 @@
             understanding of the process. It is particularly suited for early career researchers, while senior researchers are also encouraged to attend and engage in discussions on theory and methodology. 
             Participants will gain practical experience with advanced NLP methods, statistical modeling, and computational approaches to reader response studies. Basic familiarity with Python is recommended.
             (<a href="https://igelsociety.github.io/CHR2024-book-reviews-workshop/">https://igelsociety.github.io/CHR2024-book-reviews-workshop/</a>)
+            <br>
+            <br>
+            <i> Note: A maximum of 30 people can attend this workshop, and registered participants of the conference who indicated an interest in this workshop are selected on a first-come-first-serve basis.</i>
           </span>
         </div>
       </span>


### PR DESCRIPTION
Added a "note" section to the last bit of workshop description of "Analysing the Reception of Fiction Novels Across Languages" about the max number of ppl. able to attend the workshop
