### PR TITLE
Accessibility (small): add line underneath all links

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -414,3 +414,13 @@ h4 {
     color: var(--color2);
     font-size: 30px !important;
 }
+
+/* add underline for all in-text links for accesibility */
+a {
+    text-decoration: underline !important;
+}
+
+/* rm underline specifically for menu links */
+#nav-mobile a, .sidenav a {
+    text-decoration: none !important;
+}

--- a/themes/chr/static/css/main.css
+++ b/themes/chr/static/css/main.css
@@ -414,3 +414,13 @@ h4 {
     color: var(--color2);
     font-size: 30px !important;
 }
+
+/* add underline for all in-text links for accesibility */
+a {
+    text-decoration: underline !important;
+}
+
+/* rm underline specifically for menu links */
+#nav-mobile a, .sidenav a {
+    text-decoration: none !important;
+}


### PR DESCRIPTION
To comply with accessibility metrics, I have added a line underneath all links (so links aren't only distinguishable by color) 