### PR TITLE
feat: tighten up announcements page, add conference-dinner news

### DIFF
--- a/content/announcements.md
+++ b/content/announcements.md
@@ -6,7 +6,7 @@ date: 2021-02-19T16:05:25+01:00
 <style>
     div.announcements {
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(min(400px, 100%), 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(min(350px, 100%), 1fr));
         grid-column-gap: 24px;
         grid-row-gap: 24px;
     }
@@ -44,18 +44,29 @@ date: 2021-02-19T16:05:25+01:00
         border-radius: 24px;
         margin-top: auto;
         align-self: flex-start;
+        text-decoration: none !important;
     }
 </style>
 
 <div class="announcements">
     <div class="announce">
+            <a href="/announcements/aros"><img src="/images/venue/havnær-lokale.jpg" alt="Image of icecream inside of Havnær Restaurant"></a>
+            <div class="content">
+                <h3>The Conference Dinner</h3>
+                <p>
+                Join us for the conference dinner on December 5th at Restaurant Havnær, a name that translates to “close to the ocean” in Danish. Nestled at the edge of Aarhus Ø, this beautiful venue offers breathtaking views over Aarhus Bay, creating the perfect setting for a memorable evening...
+                </p>
+                <a class="link-button" href="/venue/conference-dinner" aria-label="Press to read more about the Conference Dinner">Read More</a>
+            </div>
+    </div>
+    <div class="announce">
             <a href="/announcements/aros"><img src="/images/announce/aros-outside.jpg" alt="Image outside of ARoS Art Museum"></a>
             <div class="content">
                 <h3>Discover ARoS Art Museum</h3>
                 <p>
-    As a participant in the upcoming CHR2024 conference, you have a unique opportunity to explore the renowned ARoS Art Museum, where art truly comes to life. We are excited to offer all attendees vouchers that can be used during your stay in Aarhus, giving you the chance to experience the museum’s extraordinary collections and exhibitions...
+    As a participant in the upcoming CHR2024 conference, you have a unique opportunity to explore the renowned ARoS Art Museum, where art truly comes to life. We are excited to offer all attendees vouchers that can be used during your stay in Aarhus...
                 </p>
-                <a class="link-button" href="/announcements/aros">Read More</a>
+                <a class="link-button" href="/announcements/aros" aria-label="Press to read more about ARoS Art Museum">Read More</a>
             </div>
     </div>
     <div class="announce">
@@ -65,7 +76,7 @@ date: 2021-02-19T16:05:25+01:00
                 <p>
                 The Cambridge University Press journal Computational Humanities Research (CHR) is the official journal of the CHR Conference. CHR is an open access journal in the computational humanities, publishing transdisciplinary papers that are grounded in humanities research questions and use computational, quantitative methodologies...
                 </p>
-                <a class="link-button" href="/journal">Read More</a>
+                <a class="link-button" href="/journal" aria-label="Press to read more about the CHR journal">Read More</a>
             </div>
     </div>
     <div class="announce">
@@ -75,7 +86,7 @@ date: 2021-02-19T16:05:25+01:00
                 <p>
        Registration for the 2024 Computational Humanities Conference (CHR) is now open. This years edition will take place in Aarhus, Denmark at Aarhus University on 4-6 December. The conference will be a hybrid event with an option to attend in person or virtually. Save your seat now and expect more details about CHR2024 soon…
                 </p>
-                <a class="link-button" href="https://events.au.dk/chr2024/">Register Here</a>
+                <a class="link-button" href="https://events.au.dk/chr2024/" aria-label="Press to register for the conference">Register Here</a>
             </div>
     </div>
     <div class="announce">
@@ -84,9 +95,9 @@ date: 2021-02-19T16:05:25+01:00
             <h3>Keynote Leon Derczynski</h3>
             <p>
     We are happy to announce that Professor Leon Derczynski, principal research scientist in LLM Security at NVIDIA and prof in Natural Language Processing (NLP)
-at ITU Copenhagen (IT University of Copenhagen) will give a keynote speech at the Computational Humanities Research 2024 Conference...
+at ITU Copenhagen (IT University of Copenhagen) will give a keynote speech...
             </p>
-            <a class="link-button" href="/announcements/leon-derczynski">Read More</a>
+            <a class="link-button" href="/announcements/leon-derczynski" aria-label="Press to read more about Leon Derczynski">Read More</a>
         </div>
     </div>
     <div class="announce">
@@ -107,10 +118,9 @@ enrich and analyse...
             <h3>Keynote Lauren Klein</h3>
             <p>
     We are happy to announce that Lauren Klein, Winship Distinguished Research Professor and Associate Professor in the 
-departments of Quantitative Theory & Methods and English at Emory University, will give a keynote speech at the 
-Computational Humanities Research 2024 Conference...
+departments of Quantitative Theory & Methods and English at Emory University, will give a keynote speech ...
             </p>
-            <a class="link-button" href="/announcements/lauren-klein">Read More</a>
+            <a class="link-button" href="/announcements/lauren-klein" aria-label="Press to read more about Lauren Klein">Read More</a>
         </div>
     </div>
     <div class="announce">
@@ -125,7 +135,4 @@ humanities data, including new media and cultural heritage data...
             <a class="link-button" href="/cfp">Read More</a>
         </div>
     </div>
-<!--
-
--->
 </div>

--- a/content/venue/conference-dinner.md
+++ b/content/venue/conference-dinner.md
@@ -28,7 +28,7 @@ At Havnær, the focus is on authentic experiences, combining exquisite gastronom
 
 
 <figure>
-    <img src="/images/venue/havnær-karryis-og-sovs.jpg" alt="Image inside of icecream inside of Havnær Restaurant">
+    <img src="/images/venue/havnær-karryis-og-sovs.jpg" alt="Image of icecream inside of Havnær Restaurant">
     <figcaption>Image credit: Restaurant Havnær</figcaption>
 </figure>
 

--- a/docs/announcements/index.html
+++ b/docs/announcements/index.html
@@ -97,7 +97,7 @@
         <style>
     div.announcements {
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(min(400px, 100%), 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(min(350px, 100%), 1fr));
         grid-column-gap: 24px;
         grid-row-gap: 24px;
     }
@@ -135,17 +135,28 @@
         border-radius: 24px;
         margin-top: auto;
         align-self: flex-start;
+        text-decoration: none !important;
     }
 </style>
 <div class="announcements">
+    <div class="announce">
+            <a href="/announcements/aros"><img src="/images/venue/havnær-lokale.jpg" alt="Image of icecream inside of Havnær Restaurant"></a>
+            <div class="content">
+                <h3>The Conference Dinner</h3>
+                <p>
+                Join us for the conference dinner on December 5th at Restaurant Havnær, a name that translates to “close to the ocean” in Danish. Nestled at the edge of Aarhus Ø, this beautiful venue offers breathtaking views over Aarhus Bay, creating the perfect setting for a memorable evening...
+                </p>
+                <a class="link-button" href="/venue/conference-dinner" aria-label="Press to read more about the Conference Dinner">Read More</a>
+            </div>
+    </div>
     <div class="announce">
             <a href="/announcements/aros"><img src="/images/announce/aros-outside.jpg" alt="Image outside of ARoS Art Museum"></a>
             <div class="content">
                 <h3>Discover ARoS Art Museum</h3>
                 <p>
-    As a participant in the upcoming CHR2024 conference, you have a unique opportunity to explore the renowned ARoS Art Museum, where art truly comes to life. We are excited to offer all attendees vouchers that can be used during your stay in Aarhus, giving you the chance to experience the museum’s extraordinary collections and exhibitions...
+    As a participant in the upcoming CHR2024 conference, you have a unique opportunity to explore the renowned ARoS Art Museum, where art truly comes to life. We are excited to offer all attendees vouchers that can be used during your stay in Aarhus...
                 </p>
-                <a class="link-button" href="/announcements/aros">Read More</a>
+                <a class="link-button" href="/announcements/aros" aria-label="Press to read more about ARoS Art Museum">Read More</a>
             </div>
     </div>
     <div class="announce">
@@ -155,7 +166,7 @@
                 <p>
                 The Cambridge University Press journal Computational Humanities Research (CHR) is the official journal of the CHR Conference. CHR is an open access journal in the computational humanities, publishing transdisciplinary papers that are grounded in humanities research questions and use computational, quantitative methodologies...
                 </p>
-                <a class="link-button" href="/journal">Read More</a>
+                <a class="link-button" href="/journal" aria-label="Press to read more about the CHR journal">Read More</a>
             </div>
     </div>
     <div class="announce">
@@ -165,7 +176,7 @@
                 <p>
        Registration for the 2024 Computational Humanities Conference (CHR) is now open. This years edition will take place in Aarhus, Denmark at Aarhus University on 4-6 December. The conference will be a hybrid event with an option to attend in person or virtually. Save your seat now and expect more details about CHR2024 soon…
                 </p>
-                <a class="link-button" href="https://events.au.dk/chr2024/">Register Here</a>
+                <a class="link-button" href="https://events.au.dk/chr2024/" aria-label="Press to register for the conference">Register Here</a>
             </div>
     </div>
     <div class="announce">
@@ -174,9 +185,9 @@
             <h3>Keynote Leon Derczynski</h3>
             <p>
     We are happy to announce that Professor Leon Derczynski, principal research scientist in LLM Security at NVIDIA and prof in Natural Language Processing (NLP)
-at ITU Copenhagen (IT University of Copenhagen) will give a keynote speech at the Computational Humanities Research 2024 Conference...
+at ITU Copenhagen (IT University of Copenhagen) will give a keynote speech...
             </p>
-            <a class="link-button" href="/announcements/leon-derczynski">Read More</a>
+            <a class="link-button" href="/announcements/leon-derczynski" aria-label="Press to read more about Leon Derczynski">Read More</a>
         </div>
     </div>
     <div class="announce">
@@ -197,10 +208,9 @@ enrich and analyse...
             <h3>Keynote Lauren Klein</h3>
             <p>
     We are happy to announce that Lauren Klein, Winship Distinguished Research Professor and Associate Professor in the 
-departments of Quantitative Theory & Methods and English at Emory University, will give a keynote speech at the 
-Computational Humanities Research 2024 Conference...
+departments of Quantitative Theory & Methods and English at Emory University, will give a keynote speech ...
             </p>
-            <a class="link-button" href="/announcements/lauren-klein">Read More</a>
+            <a class="link-button" href="/announcements/lauren-klein" aria-label="Press to read more about Lauren Klein">Read More</a>
         </div>
     </div>
     <div class="announce">
@@ -215,8 +225,6 @@ humanities data, including new media and cultural heritage data...
             <a class="link-button" href="/cfp">Read More</a>
         </div>
     </div>
-<!--
-<p>&ndash;&gt;</p>
 </div>
 
     </div>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -13,7 +13,7 @@
       <link>http://2024.computational-humanities-research/announcements/</link>
       <pubDate>Fri, 19 Feb 2021 16:05:25 +0100</pubDate>
       <guid>http://2024.computational-humanities-research/announcements/</guid>
-      <description>Discover ARoS Art Museum As a participant in the upcoming CHR2024 conference, you have a unique opportunity to explore the renowned ARoS Art Museum, where art truly comes to life. We are excited to offer all attendees vouchers that can be used during your stay in Aarhus, giving you the chance to experience the museum’s extraordinary collections and exhibitions... Read More CHR Journal The Cambridge University Press journal Computational Humanities Research (CHR) is the official journal of the CHR Conference.</description>
+      <description>The Conference Dinner Join us for the conference dinner on December 5th at Restaurant Havnær, a name that translates to “close to the ocean” in Danish. Nestled at the edge of Aarhus Ø, this beautiful venue offers breathtaking views over Aarhus Bay, creating the perfect setting for a memorable evening... Read More Discover ARoS Art Museum As a participant in the upcoming CHR2024 conference, you have a unique opportunity to explore the renowned ARoS Art Museum, where art truly comes to life.</description>
     </item>
     <item>
       <title>Code of conduct</title>

--- a/docs/venue/conference-dinner/index.html
+++ b/docs/venue/conference-dinner/index.html
@@ -116,7 +116,7 @@
 </figure>
 <p>At Havnær, the focus is on authentic experiences, combining exquisite gastronomy with warm, informal hospitality. Their approach reflects the charm of Jutland, meeting guests at eye level and offering a relaxed atmosphere where you can simply sit back, enjoy the moment, and take in the stunning surroundings from the SHIP building.</p>
 <figure>
-    <img src="/images/venue/havnær-karryis-og-sovs.jpg" alt="Image inside of icecream inside of Havnær Restaurant">
+    <img src="/images/venue/havnær-karryis-og-sovs.jpg" alt="Image of icecream inside of Havnær Restaurant">
     <figcaption>Image credit: Restaurant Havnær</figcaption>
 </figure>
 <p>Inspired by Nordic and French culinary traditions, the talented chef at Restaurant Havnær will prepare a delightful three-course meal, complemented by a selection of snack starters, fine wines, beverages, and coffee to finish. To cater to diverse tastes and preferences, four menu options will be available during registration:</p>


### PR DESCRIPTION
Tighten up announcements page: 
1. Make 2x2 grid appear on smaller screens (becomes 1x1 again if you minimise your computer) 
2. Make text underneath images in grid a bit more concise (e.g., by removing a sentence) 
3. Add conference dinner news 