### PR TITLE
fix typos in 'finding-the-venue' and re-add deleted session headings

### DIFF
--- a/content/programme.md
+++ b/content/programme.md
@@ -213,7 +213,7 @@ input:focus-visible + label {
 <!-- HTML FOR PROGRAMME -->
 Programme for the [pre-conference workshops](#parallel-workshops) on [Tuesday](#tuesday), 3rd December 2024, and the main conference days on [Wednesday](#wednesday), [Thursday](#thursday), and [Friday](#friday), 4th-6th December 2024. See all [accepted papers](/papers).
 
-The main venue address of CHR2024 is *Bartholins Allé 8, 8000 Aarhus C*. [Get help with finding venue locations](/venue/finding-the-venue). 
+The main venue address of CHR2024 is *Bartholins Allé 8, 8000 Aarhus C*. See [*Finding the Venue*](/venue/finding-the-venue). 
 
 *Note: Changes may occur in the programme. Please check regularly for the latest information.*
 
@@ -238,7 +238,6 @@ The main venue address of CHR2024 is *Bartholins Allé 8, 8000 Aarhus C*. [Get h
   <div class="tab-panels">
   <section id="tuesday" class="tab-panel" alt="tab showing the schedule for tuesday">
    <h2 id="overview-tue" alt="Overview of Tuesday" style="font-weight:bold;">Tuesday, December 3, 2024 (Pre-conference workshops)</h2>
-   <p style="font-style:italic">Note: Times are in Central European Time (CET)</p>
    <p>
     <ul>
       <li>09:00-12:30: <a href="#parallel-workshops"><strong>Workshop sessions</strong></a></li>
@@ -246,6 +245,7 @@ The main venue address of CHR2024 is *Bartholins Allé 8, 8000 Aarhus C*. [Get h
       <li>13:30-17:00: <a href="#parallel-workshops"><strong>Workshop sessions</strong></a></li>
     </ul>    
    </p>
+    <p style="font-style:italic">Note: Times are in Central European Time (CET)</p>
    <h3 id="parallel-workshops" style="font-weight:bold; font-size:2em;">Parallel Workshops<h3>
    <h3> Digital Methods for Mythological Research </h3>
    <p style="font-size:1em">
@@ -272,7 +272,6 @@ The main venue address of CHR2024 is *Bartholins Allé 8, 8000 Aarhus C*. [Get h
   <!-- WED -->
     <section id="wednesday" class="tab-panel" alt="tab showing the schedule for wednesday">
       <h2 id="overview-wed" alt="Overview of Wednesday" style="font-weight:bold;">Wednesday, December 4, 2024 (Day 1)</h2>
-      <p style="font-style:italic">Note: Times are in Central European Time (CET)</p>
       <p>
       <ul>
           <li>9:00-11:00: <em>Registration, breakfast and coffee</em></li>
@@ -287,7 +286,11 @@ The main venue address of CHR2024 is *Bartholins Allé 8, 8000 Aarhus C*. [Get h
           <li>17:00: Opening reception</li>
       </ul>
       </p>
+      <p style="font-style:italic">Note: Times are in Central European Time (CET)</p>
 
+<h3 style="font-weight:bold; font-size:2.3em;">Overview of Sessions</h3>
+<h2 id="session1" style="font-weight:bold; font-size:1.8em;">Session 1</h2>
+<!-- Session 1A -->
 <div class="session-block session-a">
 <h3 id="session1A" alt="Session 1A: Visual Arts and Art History (13:30-15:00)">Session 1A: Visual Arts and Art History (13:30-15:00)</h3>
 <div class="meta-data bordered-layout"><span class="meta-section"><a style="color:white;" href=https://international.au.dk/about/contact/?b=1324>Building: 1324</a>, Room: 011</span></div><p class="paper-entry"><a href="/papers/paper20" class="paper-title">Viability of Zero-shot Classification and Search of Historical Photos</a><span class="paper-type">(long)</span><span class="paper-authors">Erika Maksimova, Mari-Anna Meimer, Mari Piirsalu and Priit Järv</span></p>
@@ -304,6 +307,7 @@ The main venue address of CHR2024 is *Bartholins Allé 8, 8000 Aarhus C*. [Get h
 <p class="paper-entry"><a href="/papers/paper130" class="paper-title">Subversive Characters and Stereotyping Readers: Characterizing Queer Relationalities with Dialogue-Based Relation Extraction</a><span class="paper-type">(long)</span><span class="paper-authors">Kent K. Chang, Anna Ho and David Bamman</span></p>
 <p class="paper-entry"><a href="/papers/paper52" class="paper-title">Extracting Social Connections from Finnish Karelian Refugee Interviews Using LLMs</a><span class="paper-type">(long)</span><span class="paper-authors">Joonatan Laato, Jenna Kanerva, John Loehr, Virpi Lummaa and Filip Ginter</span></p>
 </div>
+<h2 id="session2" style="font-weight:bold; font-size:1.8em;">Session 2</h2>
       <!-- Session 2A -->
 <div class="session-block session-a">
 <h3 id="session2A" alt="Session 2A: Literature (15:30-17:00)">Session 2A: Literature (15:30-17:00)</h3>
@@ -324,7 +328,6 @@ The main venue address of CHR2024 is *Bartholins Allé 8, 8000 Aarhus C*. [Get h
   <!-- THUR -->
     <section id="thursday" class="tab-panel" alt="tab showing the schedule for thursday">
       <h2 id="overview-thu" alt="Overview of Thursday" style="font-weight:bold;">Thursday, December 5, 2024 (Day 2) </h2>
-      <p style="font-style:italic">Note: Times are in Central European Time (CET)</p>
       <p>
       <ul>
       <li>08:30-09:00: <em>Breakfast</em></li>
@@ -341,6 +344,7 @@ The main venue address of CHR2024 is *Bartholins Allé 8, 8000 Aarhus C*. [Get h
       <li>20:00: <em>Conference dinner</em></li>
       </ul>
       </p>
+      <p style="font-style:italic">Note: Times are in Central European Time (CET)</p>
       <h3 style="font-weight:bold; font-size:2.3em;">Overview of Sessions</h3>
       <h2 id="session3" style="font-weight:bold; font-size:1.8em;">Session 3</h2>
       <!-- Session 3A -->
@@ -435,7 +439,6 @@ The main venue address of CHR2024 is *Bartholins Allé 8, 8000 Aarhus C*. [Get h
     <!-- FRI -->
     <section id="friday" class="tab-panel" alt="tab showing the schedule for friday">
       <h2 id="overview-fri" alt="Overview of Friday" style="font-weight:bold;">Friday, December 6, 2024 (DAY 3)</h2>
-      <p style="font-style:italic">Note: Times are in Central European Time (CET)</p>
       <p>
         <ul>
           <li>08:30-09:00: <em>Breakfast</em></li>
@@ -451,6 +454,7 @@ The main venue address of CHR2024 is *Bartholins Allé 8, 8000 Aarhus C*. [Get h
           <li>16:30-17:00: <em>Award ceremony, concluding remarks</em></li>
         </ul>
       </p>
+      <p style="font-style:italic">Note: Times are in Central European Time (CET)</p>
       <h3 style="font-weight:bold; font-size:2em;">Overview of Sessions<h3>     
       <h2 id="session6" style="font-weight:bold; font-size:1.8em;">Session 6</h2>
       <!-- Session 6A -->

--- a/content/venue/finding-the-venue.md
+++ b/content/venue/finding-the-venue.md
@@ -70,7 +70,7 @@ The main address of the CHR2024 conference is [Bartholins Allé 8, 8000 Aarhus C
 
 
 ## Map of the Venue
-At CHR2024, all locations are conveniently within a short walking distance. Gain an overview below: 
+At CHR2024, all locations are conveniently set within a short walking distance. See the overview below:
 
 <div class="map-container">
   <img src="/images/venue/AU-MAP-FESTIVAL-EDITION-26-nov-2024.jpg" alt="Map of the conference venue with outlined areas" style="width: 100%; height: auto; border-radius: 4px;">
@@ -81,28 +81,28 @@ At CHR2024, all locations are conveniently within a short walking distance. Gain
     <span class="location-name">
       <a href="https://international.au.dk/about/contact/?b=1321" target="_blank">Building 1321</a>
     </span>
-    <div class="location-details"><br><p style="font-weight:700;font-size:1rem;">Registration and Breakfast</p></div>
+    <div class="location-details"><br><p style="font-weight:700;font-size:1rem;">Registration and Breakfast on <a href="/programme#wednesday">Wednesday</a> (December 4, 2024)</p></div>
   </div>
   <div class="location-item">
     <span class="location-marker" style="background:#479FF7;">B</span>
     <span class="location-name">
       <a href="https://international.au.dk/about/contact/?b=1343" target="_blank">Building 1343</a>
     </span>
-    <div class="location-details">Rooms: 275<br><p style="font-weight:700;font-size:1rem;">Keynotes & Award Ceremony</p></div>
+    <div class="location-details">Rooms: 275<br><p style="font-weight:700;font-size:1rem;">Keynotes, Lightning Talks & Award Ceremony</p></div>
   </div>
   <div class="location-item">
     <span class="location-marker" style="background:#EB372A">C</span>
     <span class="location-name">
       <a href="https://international.au.dk/about/contact/?b=1324" target="_blank">Building 1324</a>
     </span>
-    <div class="location-details">Rooms: 011 + 025 <br><p style="font-weight:700;font-size:1rem;">Session A (011) + Session B (025)</p></div>
+    <div class="location-details">Rooms: 011 + 025 <br><p style="font-weight:700;font-size:1rem;">Sessions A (011) + Sessions B (025)</p></div>
   </div>
   <div class="location-item">
     <span class="location-marker" style="background:#8D265E">D</span>
     <span class="location-name">
       <a href="https://international.au.dk/about/contact/?b=1342" target="_blank">Building 1342</a>
     </span>
-    <div class="location-details">Rooms: 455<br><p style="font-weight:700;font-size:1rem;">Session B on Friday only</p></div>
+    <div class="location-details">Rooms: 455<br><p style="font-weight:700;font-size:1rem;">Sessions A on <a href="/programme#friday">Friday</a> <em>only</em> (December 6th, 2024)</p></div>
   </div>
   <div class="location-item">
     <span class="location-marker" style="background:#81D554">E</span>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -657,7 +657,7 @@
       <link>http://2024.computational-humanities-research/programme/</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       <guid>http://2024.computational-humanities-research/programme/</guid>
-      <description>Programme for the pre-conference workshops on Tuesday, 3rd December 2024, and the main conference days on Wednesday, Thursday, and Friday, 4th-6th December 2024. See all accepted papers.&#xA;The main venue address of CHR2024 is Bartholins Allé 8, 8000 Aarhus C. Get help with finding venue locations.&#xA;Note: Changes may occur in the programme. Please check regularly for the latest information.&#xA;Tuesday Wednesday Thursday Friday Tuesday, December 3, 2024 (Pre-conference workshops) Note: Times are in Central European Time (CET)</description>
+      <description>Programme for the pre-conference workshops on Tuesday, 3rd December 2024, and the main conference days on Wednesday, Thursday, and Friday, 4th-6th December 2024. See all accepted papers.&#xA;The main venue address of CHR2024 is Bartholins Allé 8, 8000 Aarhus C. See Finding the Venue.&#xA;Note: Changes may occur in the programme. Please check regularly for the latest information.&#xA;Tuesday Wednesday Thursday Friday Tuesday, December 3, 2024 (Pre-conference workshops) 09:00-12:30: Workshop sessions 12:30-13:30: Lunch 13:30-17:00: Workshop sessions Note: Times are in Central European Time (CET)</description>
     </item>
     <item>
       <title>Conference Dinner at Restaurant Havnær</title>
@@ -685,7 +685,7 @@
       <link>http://2024.computational-humanities-research/venue/finding-the-venue/</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       <guid>http://2024.computational-humanities-research/venue/finding-the-venue/</guid>
-      <description>The main address of the CHR2024 conference is Bartholins Allé 8, 8000 Aarhus C, where the registration and breakfast take place on the first day. For other details on transportation, see also Getting Around in Aarhus and Conference Dinner Transport.&#xA;Map of the Venue At CHR2024, all locations are conveniently within a short walking distance. Gain an overview below:&#xA;A Building 1321 Registration and Breakfast&#xA;B Building 1343 Rooms: 275</description>
+      <description>The main address of the CHR2024 conference is Bartholins Allé 8, 8000 Aarhus C, where the registration and breakfast take place on the first day. For other details on transportation, see also Getting Around in Aarhus and Conference Dinner Transport.&#xA;Map of the Venue At CHR2024, all locations are conveniently set within a short walking distance. See the overview below:&#xA;A Building 1321 Registration and Breakfast on Wednesday (December 4, 2024)</description>
     </item>
     <item>
       <title>Getting around in Aarhus</title>

--- a/docs/programme/index.html
+++ b/docs/programme/index.html
@@ -295,7 +295,7 @@ input:focus-visible + label {
 </style>
 <!-- HTML FOR PROGRAMME -->
 <p>Programme for the <a href="#parallel-workshops">pre-conference workshops</a> on <a href="#tuesday">Tuesday</a>, 3rd December 2024, and the main conference days on <a href="#wednesday">Wednesday</a>, <a href="#thursday">Thursday</a>, and <a href="#friday">Friday</a>, 4th-6th December 2024. See all <a href="/papers">accepted papers</a>.</p>
-<p>The main venue address of CHR2024 is <em>Bartholins Allé 8, 8000 Aarhus C</em>. <a href="/venue/finding-the-venue">Get help with finding venue locations</a>.</p>
+<p>The main venue address of CHR2024 is <em>Bartholins Allé 8, 8000 Aarhus C</em>. See <a href="/venue/finding-the-venue"><em>Finding the Venue</em></a>.</p>
 <p><em>Note: Changes may occur in the programme. Please check regularly for the latest information.</em></p>
 <!-- DAYS -->
 <div class="tabset">
@@ -316,7 +316,6 @@ input:focus-visible + label {
   <div class="tab-panels">
   <section id="tuesday" class="tab-panel" alt="tab showing the schedule for tuesday">
    <h2 id="overview-tue" alt="Overview of Tuesday" style="font-weight:bold;">Tuesday, December 3, 2024 (Pre-conference workshops)</h2>
-   <p style="font-style:italic">Note: Times are in Central European Time (CET)</p>
    <p>
     <ul>
       <li>09:00-12:30: <a href="#parallel-workshops"><strong>Workshop sessions</strong></a></li>
@@ -324,6 +323,7 @@ input:focus-visible + label {
       <li>13:30-17:00: <a href="#parallel-workshops"><strong>Workshop sessions</strong></a></li>
     </ul>    
    </p>
+    <p style="font-style:italic">Note: Times are in Central European Time (CET)</p>
    <h3 id="parallel-workshops" style="font-weight:bold; font-size:2em;">Parallel Workshops<h3>
    <h3> Digital Methods for Mythological Research </h3>
    <p style="font-size:1em">
@@ -350,7 +350,6 @@ input:focus-visible + label {
   <!-- WED -->
     <section id="wednesday" class="tab-panel" alt="tab showing the schedule for wednesday">
       <h2 id="overview-wed" alt="Overview of Wednesday" style="font-weight:bold;">Wednesday, December 4, 2024 (Day 1)</h2>
-      <p style="font-style:italic">Note: Times are in Central European Time (CET)</p>
       <p>
       <ul>
           <li>9:00-11:00: <em>Registration, breakfast and coffee</em></li>
@@ -365,6 +364,10 @@ input:focus-visible + label {
           <li>17:00: Opening reception</li>
       </ul>
       </p>
+      <p style="font-style:italic">Note: Times are in Central European Time (CET)</p>
+<h3 style="font-weight:bold; font-size:2.3em;">Overview of Sessions</h3>
+<h2 id="session1" style="font-weight:bold; font-size:1.8em;">Session 1</h2>
+<!-- Session 1A -->
 <div class="session-block session-a">
 <h3 id="session1A" alt="Session 1A: Visual Arts and Art History (13:30-15:00)">Session 1A: Visual Arts and Art History (13:30-15:00)</h3>
 <div class="meta-data bordered-layout"><span class="meta-section"><a style="color:white;" href=https://international.au.dk/about/contact/?b=1324>Building: 1324</a>, Room: 011</span></div><p class="paper-entry"><a href="/papers/paper20" class="paper-title">Viability of Zero-shot Classification and Search of Historical Photos</a><span class="paper-type">(long)</span><span class="paper-authors">Erika Maksimova, Mari-Anna Meimer, Mari Piirsalu and Priit Järv</span></p>
@@ -381,6 +384,7 @@ input:focus-visible + label {
 <p class="paper-entry"><a href="/papers/paper130" class="paper-title">Subversive Characters and Stereotyping Readers: Characterizing Queer Relationalities with Dialogue-Based Relation Extraction</a><span class="paper-type">(long)</span><span class="paper-authors">Kent K. Chang, Anna Ho and David Bamman</span></p>
 <p class="paper-entry"><a href="/papers/paper52" class="paper-title">Extracting Social Connections from Finnish Karelian Refugee Interviews Using LLMs</a><span class="paper-type">(long)</span><span class="paper-authors">Joonatan Laato, Jenna Kanerva, John Loehr, Virpi Lummaa and Filip Ginter</span></p>
 </div>
+<h2 id="session2" style="font-weight:bold; font-size:1.8em;">Session 2</h2>
       <!-- Session 2A -->
 <div class="session-block session-a">
 <h3 id="session2A" alt="Session 2A: Literature (15:30-17:00)">Session 2A: Literature (15:30-17:00)</h3>
@@ -401,7 +405,6 @@ input:focus-visible + label {
   <!-- THUR -->
     <section id="thursday" class="tab-panel" alt="tab showing the schedule for thursday">
       <h2 id="overview-thu" alt="Overview of Thursday" style="font-weight:bold;">Thursday, December 5, 2024 (Day 2) </h2>
-      <p style="font-style:italic">Note: Times are in Central European Time (CET)</p>
       <p>
       <ul>
       <li>08:30-09:00: <em>Breakfast</em></li>
@@ -418,6 +421,7 @@ input:focus-visible + label {
       <li>20:00: <em>Conference dinner</em></li>
       </ul>
       </p>
+      <p style="font-style:italic">Note: Times are in Central European Time (CET)</p>
       <h3 style="font-weight:bold; font-size:2.3em;">Overview of Sessions</h3>
       <h2 id="session3" style="font-weight:bold; font-size:1.8em;">Session 3</h2>
       <!-- Session 3A -->
@@ -512,7 +516,6 @@ input:focus-visible + label {
     <!-- FRI -->
     <section id="friday" class="tab-panel" alt="tab showing the schedule for friday">
       <h2 id="overview-fri" alt="Overview of Friday" style="font-weight:bold;">Friday, December 6, 2024 (DAY 3)</h2>
-      <p style="font-style:italic">Note: Times are in Central European Time (CET)</p>
       <p>
         <ul>
           <li>08:30-09:00: <em>Breakfast</em></li>
@@ -528,6 +531,7 @@ input:focus-visible + label {
           <li>16:30-17:00: <em>Award ceremony, concluding remarks</em></li>
         </ul>
       </p>
+      <p style="font-style:italic">Note: Times are in Central European Time (CET)</p>
       <h3 style="font-weight:bold; font-size:2em;">Overview of Sessions<h3>     
       <h2 id="session6" style="font-weight:bold; font-size:1.8em;">Session 6</h2>
       <!-- Session 6A -->

--- a/docs/venue/finding-the-venue/index.html
+++ b/docs/venue/finding-the-venue/index.html
@@ -148,7 +148,7 @@
   </style>
 <p>The main address of the CHR2024 conference is <a href="https://maps.app.goo.gl/9sM2wLpzXuNjrWNr8">Bartholins Allé 8, 8000 Aarhus C</a>, where the registration and breakfast take place on the first day. For other details on transportation, see also <a href="/venue/getting-around-aarhus"><em>Getting Around in Aarhus</em></a> and <a href="/venue/conference-dinner#conference-dinner-transport"><em>Conference Dinner Transport</em></a>.</p>
 <h2 id="map-of-the-venue">Map of the Venue</h2>
-<p>At CHR2024, all locations are conveniently within a short walking distance. Gain an overview below:</p>
+<p>At CHR2024, all locations are conveniently set within a short walking distance. See the overview below:</p>
 <div class="map-container">
   <img src="/images/venue/AU-MAP-FESTIVAL-EDITION-26-nov-2024.jpg" alt="Map of the conference venue with outlined areas" style="width: 100%; height: auto; border-radius: 4px;">
 </div>
@@ -158,28 +158,28 @@
     <span class="location-name">
       <a href="https://international.au.dk/about/contact/?b=1321" target="_blank">Building 1321</a>
     </span>
-    <div class="location-details"><br><p style="font-weight:700;font-size:1rem;">Registration and Breakfast</p></div>
+    <div class="location-details"><br><p style="font-weight:700;font-size:1rem;">Registration and Breakfast on <a href="/programme#wednesday">Wednesday</a> (December 4, 2024)</p></div>
   </div>
   <div class="location-item">
     <span class="location-marker" style="background:#479FF7;">B</span>
     <span class="location-name">
       <a href="https://international.au.dk/about/contact/?b=1343" target="_blank">Building 1343</a>
     </span>
-    <div class="location-details">Rooms: 275<br><p style="font-weight:700;font-size:1rem;">Keynotes & Award Ceremony</p></div>
+    <div class="location-details">Rooms: 275<br><p style="font-weight:700;font-size:1rem;">Keynotes, Lightning Talks & Award Ceremony</p></div>
   </div>
   <div class="location-item">
     <span class="location-marker" style="background:#EB372A">C</span>
     <span class="location-name">
       <a href="https://international.au.dk/about/contact/?b=1324" target="_blank">Building 1324</a>
     </span>
-    <div class="location-details">Rooms: 011 + 025 <br><p style="font-weight:700;font-size:1rem;">Session A (011) + Session B (025)</p></div>
+    <div class="location-details">Rooms: 011 + 025 <br><p style="font-weight:700;font-size:1rem;">Sessions A (011) + Sessions B (025)</p></div>
   </div>
   <div class="location-item">
     <span class="location-marker" style="background:#8D265E">D</span>
     <span class="location-name">
       <a href="https://international.au.dk/about/contact/?b=1342" target="_blank">Building 1342</a>
     </span>
-    <div class="location-details">Rooms: 455<br><p style="font-weight:700;font-size:1rem;">Session B on Friday only</p></div>
+    <div class="location-details">Rooms: 455<br><p style="font-weight:700;font-size:1rem;">Sessions A on <a href="/programme#friday">Friday</a> <em>only</em> (December 6th, 2024)</p></div>
   </div>
   <div class="location-item">
     <span class="location-marker" style="background:#81D554">E</span>


### PR DESCRIPTION
fix typos in 'finding-the-venue' and re-add deleted session headings for wed in programme