### PR TITLE
Programme: revert to having wednesday checked

### DIFF
--- a/content/programme.md
+++ b/content/programme.md
@@ -376,13 +376,13 @@ The main venue address of CHR2024 is *Bartholins Allé 8, 8000 Aarhus C*. See [*
   <input type="radio" name="tabset" id="tuesday" aria-controls="tuesday">
   <label for="tuesday">Tuesday</label>
   <!-- WED -->
-  <input type="radio" name="tabset" id="wednesday" aria-controls="wednesday">
+  <input type="radio" name="tabset" id="wednesday" aria-controls="wednesday" checked>
   <label for="wednesday">Wednesday</label>
   <!-- THUR -->
   <input type="radio" name="tabset" id="thursday" aria-controls="thursday">
   <label for="thursday">Thursday</label>
   <!-- FRI -->
-  <input type="radio" name="tabset" id="friday" aria-controls="friday" checked>
+  <input type="radio" name="tabset" id="friday" aria-controls="friday">
   <label for="friday">Friday</label>
   
   <!-- content -->

--- a/docs/programme/index.html
+++ b/docs/programme/index.html
@@ -454,13 +454,13 @@ input:focus-visible + label {
   <input type="radio" name="tabset" id="tuesday" aria-controls="tuesday">
   <label for="tuesday">Tuesday</label>
   <!-- WED -->
-  <input type="radio" name="tabset" id="wednesday" aria-controls="wednesday">
+  <input type="radio" name="tabset" id="wednesday" aria-controls="wednesday" checked>
   <label for="wednesday">Wednesday</label>
   <!-- THUR -->
   <input type="radio" name="tabset" id="thursday" aria-controls="thursday">
   <label for="thursday">Thursday</label>
   <!-- FRI -->
-  <input type="radio" name="tabset" id="friday" aria-controls="friday" checked>
+  <input type="radio" name="tabset" id="friday" aria-controls="friday">
   <label for="friday">Friday</label>
   <!-- content -->
   <div class="tab-panels">


### PR DESCRIPTION
Reverting so that programme tab starts on Wednesday. 

It was previously on "Friday" because I changed it during #CHR2024 to always have the programme tab start on the current day of the conference! But reverting it now as it is more intuitive to click from left to right than going from right to left - in case people are still checking out our programme/papers via the conference website. 